### PR TITLE
Use docker multi stage building for reduced image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
-FROM node:lts-alpine
-RUN apk add --no-cache cronie 
-
+FROM node:lts-alpine AS builder
 WORKDIR /app
-
-COPY package*.json ./
-
-RUN npm install
 
 COPY . .
 
-RUN npm run build
+RUN npm install && npm run build
 
+
+FROM node:lts-alpine AS runner
+WORKDIR /app
+
+RUN apk add --no-cache cronie
+
+COPY --from=builder /app/dist /app/dist
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 RUN chmod +x /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
This introduces the usage of [multi-stage builds](https://docs.docker.com/build/building/multi-stage/) to reduce the size of the docker image by not including the applications dependencies.