### PR TITLE
Fix .gitignore pattern for comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,13 +17,15 @@ build/
 *.d.ts
 
 # Editor / IDE-spezifische Dateien
-.vscode/        # VS Code Konfigurationsdateien (optional, falls du sie nicht teilen möchtest)
-.idea/          # IntelliJ/WebStorm Konfigurationsdateien
-*.swp           # Vim swap files
-*.bak           # Backup files
+.vscode/
+.idea/
+# Vim swap files
+*.swp
+# Backup files
+*.bak
 *.log
 
 # Betriebssystem-spezifische Dateien
-.DS_Store       # macOS
-Thumbs.db       # Windows
+.DS_Store
+Thumbs.db
 


### PR DESCRIPTION
The [gitignore pattern format](https://git-scm.com/docs/gitignore#_pattern_format) does not allow in-line comments. Only lines starting with # are treated as comments.

This pull request moves the comments to the line above, or omits them if they have no added value.