### PR TITLE
fix: Quotes env vars in docker entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,13 +7,13 @@ if [ -z "${CONFIG_FILE}" ]; then
   echo "
   #!/bin/sh
   /usr/local/bin/node /app/dist/index.js sync \
-      --immich-url ${IMMICH_URL} \
-      --immich-key ${IMMICH_KEY} \
-      --carddav-url ${CARDDAV_URL} \
-      --carddav-username ${CARDDAV_USERNAME} \
-      --carddav-password ${CARDDAV_PASSWORD} \
-      --carddav-path-template ${CARDDAV_PATH_TEMPLATE} \
-      --carddav-addressbooks ${CARDDAV_ADDRESSBOOKS} >> /var/log/cron.log 2>&1" > /app/run.sh
+      --immich-url \"${IMMICH_URL}\" \
+      --immich-key \"${IMMICH_KEY}\" \
+      --carddav-url \"${CARDDAV_URL}\" \
+      --carddav-username \"${CARDDAV_USERNAME}\" \
+      --carddav-password \"${CARDDAV_PASSWORD}\" \
+      --carddav-path-template \"${CARDDAV_PATH_TEMPLATE}\" \
+      --carddav-addressbooks \"${CARDDAV_ADDRESSBOOKS}\" >> /var/log/cron.log 2>&1" > /app/run.sh
 else
   echo "Cron job configured for multi-sync with config file '${CONFIG_FILE}'."
   # Create the run.sh script for multi-sync mode


### PR DESCRIPTION
## Describe your changes

My caldav password contains spaces, which was breaking the docker build since bash thought the later bits were new arguments. By adding quotes around the env vars in the script gen, spaces are now safe.

Thanks for this tool!

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] Pull request title is matching the [Conventional Commits spec](https://www.conventionalcommits.org/)
